### PR TITLE
[FEAT] Dynamic HUD Visibility Based on Camera Orientation

### DIFF
--- a/fighterjet-hud/client/main.lua
+++ b/fighterjet-hud/client/main.lua
@@ -181,18 +181,24 @@ Citizen.CreateThread(function()
 end);
 
 Citizen.CreateThread(function()
+    local pitchThreshold = 60
+    local headingThreshold = 120
+    local pitch
+    local heading
+
     while true do
         Citizen.Wait(1);
-        if (inPlane) then
-            if (Config.DisableRadar) then
+
+        if inPlane then
+            if Config.DisableRadar then
                 DisplayRadar(false);
             end
             HideHudComponentThisFrame(14);
-            if (Config.OnlyFirstPerson) then
-                if (IsControlJustReleased(2, 0)) then
+            if Config.OnlyFirstPerson then
+                if IsControlJustReleased(2, 0) then
                     Citizen.CreateThread(function()
                         Citizen.Wait(100);
-                        if (GetFollowVehicleCamViewMode() == 4) then
+                        if GetFollowVehicleCamViewMode() == 4 then
                             SendNUIMessage({
                                 action = "show",
                                 color = currentColor
@@ -205,9 +211,27 @@ Citizen.CreateThread(function()
                     end);
                 end
             end
+            pitch = GetGameplayCamRelativePitch()
+            heading = GetGameplayCamRelativeHeading()
+            if heading > 60 then
+                heading = heading - 360
+            elseif heading < -60 then
+                heading = heading + 360
+            end
+            if math.abs(pitch) > pitchThreshold or math.abs(heading) > headingThreshold then
+                SendNUIMessage({
+                    action = "hide"
+                });
+            else
+                SendNUIMessage({
+                    action = "show",
+                    color = currentColor
+                });
+            end
         end
     end
 end);
+
 
 Citizen.CreateThread(function()
 	while true do


### PR DESCRIPTION
This modification implements a feature to dynamically hide or show the Heads-Up Display (HUD) in an aircraft based on the player's camera orientation. If the camera is facing behind or towards the rear of the vehicle, the HUD will automatically hide. Conversely, when the camera is oriented forward or within a normal operational view, the HUD will be displayed. This enhances gameplay by removing unnecessary HUD elements when they are not in the player's immediate view.